### PR TITLE
Removing unnecessary loops

### DIFF
--- a/index.php
+++ b/index.php
@@ -5,10 +5,12 @@ use Kirby\Cms\Template;
 include __DIR__ . '/lib/models.php';
 include __DIR__ . '/lib/functions.php';
 
+$moduleRegistry = createModuleRegistry();
+
 Kirby::plugin('medienbaecker/modules', [
-	'templates' => moduleRegistry()['templates'],
-	'pageModels' => moduleRegistry()['pageModels'],
-	'blueprints' => moduleRegistry()['blueprints'],
+	'templates' => $moduleRegistry['templates'],
+	'pageModels' => $moduleRegistry['pageModels'],
+	'blueprints' => $moduleRegistry['blueprints'],
 	'sections' => [
 		'modules' => include __DIR__ . '/lib/sections/modules.php'
 	],

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -1,6 +1,8 @@
 <?php
 
-function moduleRegistry() {
+
+function createModuleRegistry() {
+
 	$registry = ['blueprints' => [], 'templates' => [], 'pageModels' => []];
 	$modulesFolder = kirby()->root('site') . "/modules";
 	foreach (Dir::dirs($modulesFolder) as $folder) {

--- a/lib/sections/modules.php
+++ b/lib/sections/modules.php
@@ -3,7 +3,7 @@
 use Kirby\Cms\Section;
 
 $blueprints = [];
-foreach (moduleRegistry()['blueprints'] as $blueprint => $file) {
+foreach ($moduleRegistry['blueprints'] as $blueprint => $file) {
 	if(Str::startsWith($blueprint, 'pages/module.')) {
 		$blueprints[] = str_replace('pages/', '', $blueprint);
 	}


### PR DESCRIPTION
I am pretty sure calling the moduleRegistry() every time was not needed. This would scan modules folder for modules 4 and we need it just once.

There is another loop that could be merged with createModuleRegistry loop here https://github.com/iskrisis/kirby-modules/blob/eefb5d7cc6a977fb689964ec0a03d66c282d27a3/lib/sections/modules.php#L6 but that is not checking filesystem so it doesnt matter that much.