### PR TITLE
Add custom module model

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -11,7 +11,7 @@ function createModuleRegistry() {
 		if(F::exists($blueprint) AND F::exists($template)) {
 			$registry['blueprints']['pages/module.'. $folder] = $blueprint;
 			$registry['templates']['module.'. $folder] = $template;
-			$registry['pageModels']['module.'. $folder] = 'ModulePage';
+			$registry['pageModels']['module.'. $folder] = option('medienbaecker.modules.model', 'ModulePage');
 		}
 	}
 	$registry['blueprints']['pages/modules'] = [


### PR DESCRIPTION
I prefer to keep complex logic outside templates and page models are great for that.

You can already override module models individually by adding a `site/models/module.text.php` file, for example:

```php
// site/models/module.text.php

class ModuleTextPage extends ModulePage {
  // methods...
}
```

It would be great to be able to override the default module model as well. This PR adds a `medienbaecker.modules.model` option.

```php
// site/config/config.php

return [
   'medienbaecker.modules.model' => 'CustomModulePage',
];
```

```php
// site/models/module.php

class CustomModulePage extends ModulePage {
  // methods...
}
```