### PR TITLE
Add "autopublish" option

### DIFF
--- a/lib/models.php
+++ b/lib/models.php
@@ -1,6 +1,13 @@
 <?php
 
 class ModulePage extends Page {
+	public static function create(array $props) {
+		if (option('medienbaecker.modules.autopublish', true)) {
+			$props['num'] = 9999;
+		}
+		
+		return parent::create($props);
+	}
 	public function url($options = null): string {
 		return $this->parents()->filterBy('intendedTemplate', '!=', 'modules')->first()->url() . '#' . $this->slug();
 	}


### PR DESCRIPTION
This PR overrides the `Page::create` method to auto-publish modules when the `medienbaecker.modules.autopublish` option is `true`.

Should the default option value be `true` or `false`? What do you think?

By the way, `9999` is there just to ensure the module is the last published module. The actual folder `num` will follow the regular sequence.