### PR TITLE
Add fallback translation back

### DIFF
--- a/lib/sections/modules.php
+++ b/lib/sections/modules.php
@@ -22,11 +22,11 @@ return array_replace_recursive($base, [
 		'create' => function ($create = null) use ($blueprints) {
 			return $create ?? $blueprints;
 		},
-		'empty' => function ($empty = 'modules.empty') {
-			return I18n::translate($empty, $empty);
+		'empty' => function ($empty = null) {
+			return $empty ?? I18n::translate('modules.empty');
 		},
-		'headline' => function ($headline = 'modules') {
-			return I18n::translate($headline, $headline);
+		'headline' => function ($headline = null) {
+			return $headline ?? I18n::translate('modules');
 		},
 		'info' => function(string $info = '{{ page.moduleName }}') {
 			return $info;

--- a/lib/sections/modules.php
+++ b/lib/sections/modules.php
@@ -23,10 +23,10 @@ return array_replace_recursive($base, [
 			return $create ?? $blueprints;
 		},
 		'empty' => function ($empty = 'modules.empty') {
-			return I18n::translate($empty);
+			return I18n::translate($empty, $empty);
 		},
 		'headline' => function ($headline = 'modules') {
-			return I18n::translate($headline);
+			return I18n::translate($headline, $headline);
 		},
 		'info' => function(string $info = '{{ page.moduleName }}') {
 			return $info;


### PR DESCRIPTION
Without the fallback translation, the text defined on the section `headline` in the blueprint is never used.