### PR TITLE
Make "modules" method stringable

### DIFF
--- a/index.php
+++ b/index.php
@@ -20,17 +20,15 @@ Kirby::plugin('medienbaecker/modules', [
 	],
 	'pageMethods' => [
 		'renderModules' => function () {
-			if ($modules = $this->find('modules')) {
-				foreach ($modules->childrenAndDrafts() as $module) {
-					if(!$module->isListed() && !$module->isDraft()) continue;
-					if($module->isDraft && !$module->isVerified(get('token'))) continue;
-					$moduleTemplate = new Template($module->intendedTemplate());
-					echo $moduleTemplate->render([
-						'page' => $this,
-						'module' => $module,
-						'site' => $this->site()
-					]);
-				}
+			foreach ($this->modules() as $module) {
+				if (!$module->isListed() && !$module->isDraft()) continue;
+				if ($module->isDraft && !$module->isVerified(get('token'))) continue;
+				$moduleTemplate = new Template($module->intendedTemplate());
+				echo $moduleTemplate->render([
+					'page' => $this,
+					'module' => $module,
+					'site' => $this->site()
+				]);
 			}
 		},
 		'hasModules' => function () {
@@ -40,10 +38,13 @@ Kirby::plugin('medienbaecker/modules', [
 			return count($modules) > 0;
 		},
 		'modules' => function () {
-			if ($modules = $this->find('modules')) {
-				return $modules->children();
+			$modules = new ModulesCollection;
+
+			if ($rawModules = $this->find('modules')) {
+				$modules = $modules->merge($rawModules->childrenAndDrafts()->data());
 			}
-			return [];
+
+			return $modules;
 		},
 		'isModule' => function () {
 			return Str::startsWith($this->intendedTemplate(), 'module.');

--- a/index.php
+++ b/index.php
@@ -4,6 +4,7 @@ use Kirby\Cms\Template;
 
 include __DIR__ . '/lib/models.php';
 include __DIR__ . '/lib/functions.php';
+include __DIR__ . '/lib/collection.php';
 
 $moduleRegistry = createModuleRegistry();
 

--- a/lib/collection.php
+++ b/lib/collection.php
@@ -1,0 +1,27 @@
+<?php
+
+use Kirby\Cms\Pages;
+use Kirby\Cms\Template;
+
+class ModulesCollection extends Pages {
+	/**
+	 * Converts the object to a string
+	 *
+	 * @return string
+	 */
+	public function toString(): string
+	{
+		$html = '';
+
+		foreach ($this->data() as $module) {
+			$moduleTemplate = new Template($module->intendedTemplate());
+			$html .= $moduleTemplate->render([
+				'page' => $module->parent(),
+				'module' => $module,
+				'site' => site(),
+			]);
+		}
+
+		return $html;
+	}
+}


### PR DESCRIPTION
As discussed at #22. `$page->modules()` can now be used as an array or echoed as a string.

I haven't tested other methods.