### PR TITLE
Enable inline previews + Kirby 3.7 compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,31 +1,44 @@
 panel.plugin('medienbaecker/modules', {
-	components: {
-		'k-modules-section': {
-			extends: 'k-pages-section',
-			created: function () {
-				if (this.parent == 'site') return;
-				this.$api.post(this.parent + '/modules')
-					.then((data) => {
-						if (data.created) {
-							this.reload();
-						}
-					});
-			},
-			updated: function () {
-				this.$nextTick(function () {
-					this.$el.classList.add('k-modules-section');
-				})
-			}
-		},
-	},
-	fields: {
-		modules_redirect: {
-			props: {
-				redirect: String
-			},
-			render: function() {
-				window.location.href = this.redirect;
-			}
-		}
-	}
+  components: {
+    'k-modules-section': {
+      extends: 'k-pages-section',
+      created: function () {
+        if (this.parent == 'site') return;
+        this.$api.post(this.parent + '/modules').then((data) => {
+          if (data.created) {
+            this.reload();
+          }
+        });
+      },
+      computed: {
+        type() {
+          return 'modules';
+        }
+      },
+      methods: {
+        onAdd() {
+          if (this.canAdd) {
+            this.$dialog('pages/create', {
+              query: {
+                parent: this.options.link || this.parent,
+                view: this.parent,
+                section: this.name,
+                modules: this.options.layout
+              }
+            });
+          }
+        }
+      }
+    }
+  },
+  fields: {
+    modules_redirect: {
+      props: {
+        redirect: String
+      },
+      render: function () {
+        window.location.href = this.redirect;
+      }
+    }
+  }
 });

--- a/lib/fields/redirect.php
+++ b/lib/fields/redirect.php
@@ -1,14 +1,19 @@
 <?php
 
 return [
-	'computed' => [
-		'redirect' => function () {
-			if($this->model()->isHomePage()) {
-				return $this->model()->site()->panelUrl();	
-			}
-			else {
-				return $this->model()->parent()->panelUrl();	
-			}
-		}
-	]
+    'computed' => [
+        'redirect' => function () {
+            if ($this->model()->isHomePage()) {
+                return $this->model()
+                    ->site()
+                    ->panel()
+                    ->url();
+            } else {
+                return $this->model()
+                    ->parent()
+                    ->panel()
+                    ->url();
+            }
+        }
+    ]
 ];

--- a/lib/models.php
+++ b/lib/models.php
@@ -29,6 +29,10 @@ class ModulePage extends Page {
 	public function moduleId() {
 		return str_replace('.', '__', $this->intendedTemplate());
 	}
+    public function parents(){
+        $parents = parent::parents();
+        return $parents->filter('slug', '!=', 'modules');
+    }
 }
 
 class ModulesPage extends Page {
@@ -38,4 +42,8 @@ class ModulesPage extends Page {
 	public function render(array $data = [], $contentType = 'html'): string {
 		go($this->parent()->url());
 	}
+    public function parents(){
+        $parents = parent::parents();
+        return $parents->filter('slug', '!=', 'modules');
+    }
 }

--- a/lib/sections/modules.php
+++ b/lib/sections/modules.php
@@ -4,42 +4,46 @@ use Kirby\Cms\Section;
 
 $blueprints = [];
 foreach ($moduleRegistry['blueprints'] as $blueprint => $file) {
-	if(Str::startsWith($blueprint, 'pages/module.')) {
+    if (Str::startsWith($blueprint, 'pages/module.')) {
 		$blueprints[] = str_replace('pages/', '', $blueprint);
-	}
+    }
 }
 $default = array_search('module.' . option('medienbaecker.modules.default', 'text'), $blueprints);
-if($default !== false) {
-	$module_text = $blueprints[$default];
-	unset($blueprints[$default]);
-	array_unshift($blueprints, $module_text);
+if ($default !== false) {
+    $module_text = $blueprints[$default];
+    unset($blueprints[$default]);
+    array_unshift($blueprints, $module_text);
 }
 
 $base = Section::$types['pages'];
 
 if (is_string($base)) {
-	$base = include $base;
+    $base = include $base;
 }
 
 return array_replace_recursive($base, [
-	'props' => [
-		'create' => function ($create = null) use ($blueprints) {
-			return $create ?? $blueprints;
-		},
-		'empty' => function ($empty = null) {
-			return $empty ?? I18n::translate('modules.empty');
-		},
-		'headline' => function ($headline = null) {
-			return $headline ?? I18n::translate('modules');
-		},
-		'info' => function(string $info = '{{ page.moduleName }}') {
-			return $info;
-		},
-		'image' => false,
-		'parent' => function($parent = null) {
-			return $this->model()->find('modules')
-				? 'page.find("modules")'
-				: $parent;
-		}
-	]
+    'props' => [
+        'create' => function ($create = null) use ($blueprints) {
+            return $create ?? $blueprints;
+        },
+        'empty' => function ($empty = null) {
+            return $empty ?? I18n::translate('modules.empty');
+        },
+        'headline' => function ($headline = null) {
+            return $headline ?? I18n::translate('modules');
+        },
+        'info' => function (string $info = '{{ page.moduleName }}') {
+            return $info;
+        },
+        'image' => false,
+        'parent' => function ($parent = null) {
+            return $this->model()->find('modules')
+                ? 'page.find("modules")'
+                : $parent;
+        },
+        'layout' => function (string $layout = 'list') {
+            $layouts = ['list', 'cardlets', 'cards', 'table', 'module'];
+            return in_array($layout, $layouts) ? $layout : 'list';
+        }
+    ]
 ]);


### PR DESCRIPTION
This pull request adds a custom `layout` type `module` for modules sections which can be used by other plugins to customize the item layout, e. g. enabling inline editing: https://github.com/hananils/kirby-modules-inline (still experimental, but hey, it seems to work 🎉).

Furthermore, it updates the codebase for Kirby 3.7 and removes the modules page from the breadcrumb.
