### PR TITLE
Properly fetch the parent page of the module

### DIFF
--- a/lib/collection.php
+++ b/lib/collection.php
@@ -14,13 +14,24 @@ class ModulesCollection extends Pages {
 
     foreach ($this->data() as $module) {
       $moduleTemplate = new Template($module->intendedTemplate());
+      $page = $this->getParentPage($module);
       $html .= $moduleTemplate->render([
-        'page' => $module->parent(),
+        'page' => $page,
         'module' => $module,
         'site' => site(),
       ]);
     }
 
     return $html;
+  }
+
+  private function getParentPage($module): ?Page
+  {
+    $page = $module->parent();
+    while (!is_null($page) and get_class($page) === "ModulesPage") {
+      $page = $page->parent();
+    }
+
+    return $page;
   }
 }


### PR DESCRIPTION
This is a possible solution in order to get the right parent page when working in the PHP file of the module.
Without these changes, the "$page" object points to its "technical" parent, which is the "ModulesPage" element.
With these changes, the "$page" object points to its expected parent, which is the page that has the modules' section implemented.