### PR TITLE
fix indexing for seo sitemap

### DIFF
--- a/lib/models.php
+++ b/lib/models.php
@@ -32,6 +32,9 @@ class ModulePage extends Page {
     $parents = parent::parents();
     return $parents->filter('slug', '!=', 'modules');
   }
+	public function metaDefaults() {
+		return ['robotsIndex' => false];
+	}
 }
 
 class ModulesPage extends Page {
@@ -41,4 +44,7 @@ class ModulesPage extends Page {
   public function render(array $data = [], $contentType = 'html'): string {
     go($this->parentUrl());
   }
+	public function metaDefaults() {
+		return ['robotsIndex' => false];
+	}
 }


### PR DESCRIPTION
when using modules together with the kirby seo plugin https://plugins.andkindness.com/seo/  the modules folder and its subpages are in the sitemap.

this fix prevents that.